### PR TITLE
Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ $ python3 -m install .[tests]
 $ pytest -v
 ```
 
+To build the docs:
+
+```bash
+$ python3 -m install .[docs]
+$ cd docs
+$ make html
+```
+
 ## Usage
 
 A GEQDSK file may be read using the `geqdsk.read` function:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/_fileutils.rst
+++ b/docs/source/_fileutils.rst
@@ -8,11 +8,10 @@ This reference material is intended for developers, and users are not recommende
 use these functions directly.
 
 .. autoclass:: freeqdsk._fileutils.ChunkOutput
-  :members:
-  :special-members:
+   :members:
+   :special-members:
 
 .. automethod:: freeqdsk._fileutils.f2s
 .. automethod:: freeqdsk._fileutils.write_1d
 .. automethod:: freeqdsk._fileutils.write_2d
 .. automethod:: freeqdsk._fileutils.next_value
-

--- a/docs/source/_fileutils.rst
+++ b/docs/source/_fileutils.rst
@@ -1,0 +1,18 @@
+.. _sec-fileutils:
+
+_fileutils
+==========
+
+The file ``_fileutils.py`` contains utility functions for reading/writing EQDSK files.
+This reference material is intended for developers, and users are not recommended to
+use these functions directly.
+
+.. autoclass:: freeqdsk._fileutils.ChunkOutput
+  :members:
+  :special-members:
+
+.. automethod:: freeqdsk._fileutils.f2s
+.. automethod:: freeqdsk._fileutils.write_1d
+.. automethod:: freeqdsk._fileutils.write_2d
+.. automethod:: freeqdsk._fileutils.next_value
+

--- a/docs/source/aeqdsk.rst
+++ b/docs/source/aeqdsk.rst
@@ -1,0 +1,15 @@
+.. _sec-aeqdsk:
+
+aeqdsk
+======
+
+The file ``aeqdsk.py`` contains functions for reading and writing A-EQDSK files, which
+contain a wide variety of diagnostics information.
+
+.. autofunction:: freeqdsk.aeqdsk.read
+.. autofunction:: freeqdsk.aeqdsk.write
+
+.. autoclass:: freeqdsk.aeqdsk.Field
+   :members:
+
+.. autofunction:: freeqdsk.aeqdsk.fields

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,67 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import sys
+
+from importlib.metadata import version as get_version
+
+sys.path.insert(0, os.path.abspath('..'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'FreeQDSK'
+copyright = '2023, Ben Dudson'
+author = 'Ben Dudson'
+
+# The full version, including alpha/beta/rc tags
+release = get_version(project)
+# Major.minor version
+version = ".".join(release.split(".")[:2])
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "myst_parser",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+autodoc_type_aliases = {
+    "ArrayLike": "numpy.typing.ArrayLike",
+}
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+pygments_style = "sphinx"

--- a/docs/source/geqdsk.rst
+++ b/docs/source/geqdsk.rst
@@ -9,4 +9,3 @@ Grad-Shafranov solver, or by fitting to experimental measurements.
 
 .. automethod:: freeqdsk.geqdsk.read
 .. automethod:: freeqdsk.geqdsk.write
-

--- a/docs/source/geqdsk.rst
+++ b/docs/source/geqdsk.rst
@@ -1,0 +1,12 @@
+.. _sec-geqdsk:
+
+geqdsk
+======
+
+The file ``geqdsk.py`` contains functions for reading and writing G-EQDSK files, which
+describe Grad-Shafranov tokamak plasma equilibria. These may be generated via a
+Grad-Shafranov solver, or by fitting to experimental measurements.
+
+.. automethod:: freeqdsk.geqdsk.read
+.. automethod:: freeqdsk.geqdsk.write
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,29 @@
+FreeQDSK
+========
+
+Introduction
+------------
+
+FreeQDSK is a Python library for reading/writing EQDSK files used to describe plasmas in
+tokamak fusion devices. The following file types are currently supported:
+
+- A-EQDSK: Plasma diagnostics data.
+- G-EQDSK: Grad-Shafranov equilibrium data.
+
+FreeQDSK is adapted from FreeGS_, by Ben Dudson.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   _fileutils.rst
+   geqdsk.rst
+
+.. _FreeGS: https://github.com/freegs-plasma/freegs
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,8 +16,9 @@ FreeQDSK is adapted from FreeGS_, by Ben Dudson.
    :maxdepth: 2
    :caption: Contents:
 
-   _fileutils.rst
+   aeqdsk.rst
    geqdsk.rst
+   _fileutils.rst
 
 .. _FreeGS: https://github.com/freegs-plasma/freegs
 

--- a/freeqdsk/_fileutils.py
+++ b/freeqdsk/_fileutils.py
@@ -6,39 +6,57 @@ SPDX-FileCopyrightText: © 2016 Ben Dudson, University of York.
 SPDX-License-Identifier: MIT
 
 """
+from __future__ import annotations  # noqa
 
 import re
+from typing import Any, Generator, Iterable, List, TextIO, Union
+
+import numpy as np
+from numpy.typing import ArrayLike
 
 
-def f2s(f):
+def f2s(f: float) -> str:
+    r"""
+    Format a string containing a float.
+
+    Positive floats require a extra space in front to ensure that positive and negative
+    values have the same width.
+
+    Parameters
+    ----------
+    f: float
+        A single float to be converted to a string.
+
+    Returns
+    -------
+    str
+        Converted string.
     """
-    Format a string containing a float
-    """
-    s = ""
-    if f >= 0.0:
-        s += " "
-    return s + "%1.9E" % f
+    return f"{' ' if f >= 0.0 else ''}{f:1.9E}"
 
 
 class ChunkOutput:
-    """
-    This outputs values in lines, inserting
-    newlines when needed.
+    r"""
+    Outputs values in lines, inserting newlines when needed.
+
+    Parameters
+    ---------
+    filehandle: TextIO
+        Output to write to.
+    chunksize: int, default 5
+        Number of values per line.
+    extraspaces: int, default 0
+        Number of extra spaces between outputs
     """
 
-    def __init__(self, filehandle, chunksize=5, extraspaces=0):
-        """
-        filehandle  output to write to
-        chunksize   number of values on a line
-        extraspaces  number of extra spaces between outputs
-        """
+    def __init__(self, filehandle: TextIO, chunksize: int = 5, extraspaces: int = 0):
         self.fh = filehandle
         self.counter = 0
         self.chunk = chunksize
         self.extraspaces = extraspaces
 
-    def write(self, value):
-        """
+    def write(self, value: Union[int, float, List[Any]]) -> None:
+        r"""
         Write a value to the output, adding a newline if needed
 
         Distinguishes between:
@@ -46,6 +64,11 @@ class ChunkOutput:
         - int   : Converts using str
         - float : Converts using f2s to Fortran-formatted string
 
+        Parameters
+        ----------
+        value: Union[int, float, List[Any]]
+            Either a single int or float, or a list to output. If provided with a list,
+            the function is called recursively on each element.
         """
         if isinstance(value, list):
             for elt in value:
@@ -55,7 +78,7 @@ class ChunkOutput:
         self.fh.write(" " * self.extraspaces)
 
         if isinstance(value, int):
-            self.fh.write("   " + str(value))
+            self.fh.write(f"   {value}")
         else:
             self.fh.write(f2s(value))
 
@@ -64,58 +87,95 @@ class ChunkOutput:
             self.fh.write("\n")
             self.counter = 0
 
-    def newline(self):
+    def newline(self) -> None:
         """
-        Ensure that the file is at the start of a new line
+        Ensure that the file is at the start of a new line. If the file is already
+        at a newline, does nothing.
         """
         if self.counter != 0:
-            self.fh.write("\n")
-            self.counter = 0
+            self.endblock()
 
-    def endblock(self):
+    def endblock(self) -> None:
         """
-        Make sure next block of data is on new line
+        Make sure next block of data is on new line.
         """
         self.fh.write("\n")
         self.counter = 0
 
     def __enter__(self):
+        """
+        Entry point for ``with`` statements.
+        """
         return self
 
-    def __exit__(self, type, value, traceback):
-        """Ensure that the chunk finishes with a new line"""
-        if self.counter != 0:
-            self.counter = 0
-            self.fh.write("\n")
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Exit point for ``with`` statements.
+
+        Ensures that the chunk finishes with a new line.
+        """
+        self.newline()
 
 
-def write_1d(val, out):
+def write_1d(values: Iterable[Any], out: ChunkOutput) -> None:
+    r"""
+    Writes a 1D variable to a ChunkOutput file handle.
+
+    Parameters
+    ----------
+    values: Iterable[Any]
+        List of values to write.
+    out: ChunkOutput
+       File handle managed by a ``ChunkOutput`` object.
     """
-    Writes a 1D variable val to the file handle out
-    """
-    for i in range(len(val)):
-        out.write(val[i])
+    for value in values:
+        out.write(value)
     out.newline()
 
 
-def write_2d(val, out):
+def write_2d(values: ArrayLike, out: ChunkOutput) -> None:
+    r"""
+    Writes a 2D array to a ChunkOutput file handle.
+
+    Note that this transposes the array, looping over the first index fastest
+
+    Parameters
+    ----------
+    values: ArrayLike
+        List of values to write.
+    out: ChunkOutput
+       File handle managed by a ``ChunkOutput`` object.
+
+    Raises
+    ------
+    ValueError
+        If values is not a 2D array.
     """
-    Writes a 2D array. Note that this transposes
-    the array, looping over the first index fastest
-    """
-    nx, ny = val.shape
+    # Alt: Check values is 2D, then write_1d(np.asarray(values).T.ravel(), out)
+    nx, ny = np.shape(values)
     for y in range(ny):
         for x in range(nx):
-            out.write(val[x, y])
+            out.write(values[x, y])
     out.newline()
 
 
-def next_value(fh):
+def next_value(fh: TextIO) -> Generator[Union[int, float], None, None]:
     """
-    A generator which yields values from a file handle
+    A generator which yields values from a file handle.
 
-    Checks if the value is a float or int, returning
-    the correct type depending on if '.' is in the string
+    Checks if the value is a float or int, returning the correct type depending on
+    whether '.' is in the string.
+
+    Parameters
+    ----------
+    fh: TextIO
+        File handle for text file to be read.
+
+    Yields
+    ------
+    Union[int, float]
+        Yields either an int or a float, depending on whether the string contains a
+        decimal point.
     """
     pattern = re.compile(r"[ +\-]?\d+(?:\.\d+(?:[Ee][\+\-]\d\d)?)?")
 

--- a/freeqdsk/aeqdsk.py
+++ b/freeqdsk/aeqdsk.py
@@ -69,21 +69,17 @@ def fields() -> List[Field]:
         (
             "betap",
             1.0,
-            dedent(
-                """\
-                poloidal beta with normalization average poloidal magnetic BPOLAV\
-                defined through Ampere's law\
-                """
+            (
+                "poloidal beta with normalization average poloidal magnetic BPOLAV "
+                "defined through Ampere's law"
             ),
         ),
         (
             "ali",
             0.0,
-            dedent(
-                """\
-                li with normalization average poloidal magnetic defined through\
-                Ampere's law\
-                """
+            (
+                "li with normalization average poloidal magnetic defined through "
+                "Ampere's law"
             ),
         ),
         ("oleft", 10.0, "plasma inner gap in cm"),
@@ -148,11 +144,9 @@ def fields() -> List[Field]:
         (
             "xndnt",
             0.0,
-            dedent(
-                """\
-                vertical stability parameter, vacuum field index normalized to critical\
-                index value\
-                """
+            (
+                "vertical stability parameter, vacuum field index normalized to "
+                "critical index value"
             ),
         ),
         ("rseps1", 1.0, "major radius of x point in cm"),
@@ -169,12 +163,10 @@ def fields() -> List[Field]:
         (
             "seplim",
             0.0,
-            dedent(
-                """\
-                > 0 for minimum gap in cm in divertor configurations, < 0 absolute\
-                value for minimum distance to external separatrix in limiter\
-                configurations\
-                """
+            (
+                "> 0 for minimum gap in cm in divertor configurations, < 0 absolute "
+                "value for minimum distance to external separatrix in limiter "
+                "configurations"
             ),
         ),
         ("rmagx", 100.0, "major radius in cm at magnetic axis"),
@@ -261,11 +253,9 @@ def fields() -> List[Field]:
         (
             "cjor0",
             0.0,
-            dedent(
-                """\
-                normalized flux surface average current density at 99% of normalized\
-                poloidal flux\
-                """
+            (
+                "normalized flux surface average current density at 99% of normalized "
+                "poloidal flux"
             ),
         ),
         ("fexpan", 0.0, "flux expansion at x point"),
@@ -284,11 +274,9 @@ def fields() -> List[Field]:
         (
             "cj1ave",
             0.0,
-            dedent(
-                """\
-                normalized average current density in plasma outer 5% normalized\
-                poloidal flux region\
-                """
+            (
+                "normalized average current density in plasma outer 5% normalized "
+                "poloidal flux region"
             ),
         ),
         ("rmidin", 0.0, "inner major radius in m at Z=0.0"),

--- a/freeqdsk/aeqdsk.py
+++ b/freeqdsk/aeqdsk.py
@@ -8,261 +8,314 @@ SPDX-License-Identifier: MIT
 
 """
 
-from . import _fileutils as fu
-from textwrap import dedent
-
 import warnings
+from textwrap import dedent
+from typing import Any, Callable, Dict, List, NamedTuple, TextIO, Tuple, Union
 
-# List of file data variables, default values, and documentation
-# This is used in both reader and writer
-fields = [
-    (
-        "tsaisq",
-        0.0,
-        "total chi2 from magnetic probes, flux loops, Rogowski and external coils",
-    ),
-    ("rcencm", 100.0, "major radius in cm for vacuum field BCENTR"),
-    ("bcentr", 1.0, "vacuum toroidal magnetic field in Tesla at RCENCM"),
-    ("pasmat", 1e6, "measured plasma toroidal current in Ampere"),
-    ("cpasma", 1e6, "fitted plasma toroidal current in Ampere-turn"),
-    ("rout", 100.0, "major radius of geometric center in cm"),
-    ("zout", 0.0, "Z of geometric center in cm"),
-    ("aout", 50.0, "plasma minor radius in cm"),
-    ("eout", 1.0, "Plasma boundary elongation"),
-    ("doutu", 1.0, "upper triangularity"),
-    ("doutl", 1.0, "lower triangularity"),
-    ("vout", 1000.0, "plasma volume in cm3"),
-    ("rcurrt", 100.0, "major radius in cm of current centroid"),
-    ("zcurrt", 0.0, "Z in cm at current centroid"),
-    ("qsta", 5.0, "equivalent safety factor q*"),
-    ("betat", 1.0, "toroidal beta in %"),
-    (
-        "betap",
-        1.0,
-        dedent(
-            """\
-            poloidal beta with normalization average poloidal magnetic BPOLAV defined
-            through Ampere's law
-            """
-        ),
-    ),
-    (
-        "ali",
-        0.0,
-        "li with normalization average poloidal magnetic defined through Ampere's law",
-    ),
-    ("oleft", 10.0, "plasma inner gap in cm"),
-    ("oright", 10.0, "plasma outer gap in cm"),
-    ("otop", 10.0, "plasma top gap in cm"),
-    ("obott", 10.0, "plasma bottom gap in cm"),
-    ("qpsib", 5.0, "q at 95% of poloidal flux"),
-    ("vertn", 1.0, "vacuum field (index? -- seems to be float) at current centroid"),
-    # fmt_1040 = r '^\s*' + 4 * r '([\s\-]\d+\.\d+[Ee][\+\-]\d\d)'
-    # read(neqdsk, 1040)(rco2v(k, jj), k = 1, mco2v)
-    (None, None, None),  # New line
-    (
-        "rco2v",
-        lambda data: [0.0] * data["mco2v"],
-        "1D array : path length in cm of vertical CO2 density chord",
-    ),
-    # read(neqdsk, 1040)(dco2v(jj, k), k = 1, mco2v)
-    (None, None, None),  # New line
-    (
-        "dco2v",
-        lambda data: [0.0] * data["mco2v"],
-        "line average electron density in cm3 from vertical CO2 chord",
-    ),
-    # read(neqdsk, 1040)(rco2r(k, jj), k = 1, mco2r)
-    (None, None, None),  # New line
-    (
-        "rco2r",
-        lambda data: [0.0] * data["mco2r"],
-        "path length in cm of radial CO2 density chord",
-    ),
-    # read(neqdsk, 1040)(dco2r(jj, k), k = 1, mco2r)
-    (None, None, None),  # New line
-    (
-        "dco2r",
-        lambda data: [0.0] * data["mco2r"],
-        "line average electron density in cm3 from radial CO2 chord",
-    ),
-    (None, None, None),  # New line
-    ("shearb", 0.0, ""),
-    (
-        "bpolav",
-        1.0,
-        "average poloidal magnetic field in Tesla defined through Ampere's law",
-    ),
-    ("s1", 0.0, "Shafranov boundary line integrals"),
-    ("s2", 0.0, "Shafranov boundary line integrals"),
-    ("s3", 0.0, "Shafranov boundary line integrals"),
-    ("qout", 0.0, "q at plasma boundary"),
-    ("olefs", 0.0, ""),
-    ("orighs", 0.0, "outer gap of external second separatrix in cm"),
-    ("otops", 0.0, "top gap of external second separatrix in cm"),
-    ("sibdry", 1.0, ""),
-    ("areao", 100.0, "cross sectional area in cm2"),
-    ("wplasm", 0.0, ""),
-    ("terror", 0.0, "equilibrium convergence error"),
-    ("elongm", 0.0, "elongation at magnetic axis"),
-    ("qqmagx", 0.0, "axial safety factor q(0)"),
-    ("cdflux", 0.0, "computed diamagnetic flux in Volt-sec"),
-    ("alpha", 0.0, "Shafranov boundary line integral parameter"),
-    ("rttt", 0.0, "Shafranov boundary line integral parameter"),
-    ("psiref", 1.0, "reference poloidal flux in VS/rad"),
-    (
-        "xndnt",
-        0.0,
-        dedent(
-            """\
-            vertical stability parameter, vacuum field index normalized to critical
-            index value
-            """
-        ),
-    ),
-    ("rseps1", 1.0, "major radius of x point in cm"),
-    ("zseps1", -1.0, ""),
-    ("rseps2", 1.0, "major radius of x point in cm"),
-    ("zseps2", 1.0, ""),
-    ("sepexp", 0.0, "separatrix radial expansion in cm"),
-    ("obots", 0.0, "bottom gap of external second separatrix in cm"),
-    ("btaxp", 1.0, "toroidal magnetic field at magnetic axis in Tesla"),
-    ("btaxv", 1.0, "vacuum toroidal magnetic field at magnetic axis in Tesla"),
-    ("aaq1", 100.0, "minor radius of q=1 surface in cm, 100 if not found"),
-    ("aaq2", 100.0, "minor radius of q=2 surface in cm, 100 if not found"),
-    ("aaq3", 100.0, "minor radius of q=3 surface in cm, 100 if not found"),
-    (
-        "seplim",
-        0.0,
-        dedent(
-            """\
-            > 0 for minimum gap in cm in divertor configurations, < 0 absolute value for
-            minimum distance to external separatrix in limiter configurations
-            """
-        ),
-    ),
-    ("rmagx", 100.0, "major radius in cm at magnetic axis"),
-    ("zmagx", 0.0, ""),
-    ("simagx", 0.0, "Poloidal flux at the magnetic axis"),
-    ("taumhd", 0.0, "energy confinement time in ms"),
-    ("betapd", 0.0, "diamagnetic poloidal b"),
-    ("betatd", 0.0, "diamagnetic toroidal b in %"),
-    ("wplasmd", 0.0, "diamagnetic plasma stored energy in Joule"),
-    ("diamag", 0.0, "measured diamagnetic flux in Volt-sec"),
-    ("vloopt", 0.0, "measured loop voltage in volt"),
-    ("taudia", 0.0, "diamagnetic energy confinement time in ms"),
-    (
-        "qmerci",
-        0.0,
-        "Mercier stability criterion on axial q(0), q(0) > QMERCI for stability",
-    ),
-    ("tavem", 0.0, "average time in ms for magnetic and MSE data"),
-    # ishot > 91000
-    # The next section is dependent on the EFIT version
-    # New version of EFIT on 05/24/97 writes aeqdsk that includes
-    # data values for parameters nsilop,magpri,nfcoil and nesum.
-    (None, True, None),  # New line
-    (
-        "nsilop",
-        lambda data: len(data.get("csilop", [])),
-        "Number of flux loop signals, len(csilop)",
-    ),
-    (
-        "magpri",
-        lambda data: len(data.get("cmpr2", [])),
-        "Number of flux loop signals, len(cmpr2) (added to nsilop)",
-    ),
-    (
-        "nfcoil",
-        lambda data: len(data.get("ccbrsp", [])),
-        "Number of calculated external coil currents, len(ccbrsp)",
-    ),
-    (
-        "nesum",
-        lambda data: len(data.get("eccurt", [])),
-        "Number of measured E-coil currents",
-    ),
-    (None, None, None),  # New line
-    (
-        "csilop",
-        lambda data: [0.0] * data.get("nsilop", 0),
-        "computed flux loop signals in Weber",
-    ),
-    ("cmpr2", lambda data: [0.0] * data.get("magpri", 0), ""),
-    (
-        "ccbrsp",
-        lambda data: [0.0] * data.get("nfcoil", 0),
-        "computed external coil currents in Ampere",
-    ),
-    (
-        "eccurt",
-        lambda data: [0.0] * data.get("nesum", 0),
-        "measured E-coil current in Ampere",
-    ),
-    ("pbinj", 0.0, "neutral beam injection power in Watts"),
-    ("rvsin", 0.0, "major radius of vessel inner hit spot in cm"),
-    ("zvsin", 0.0, "Z of vessel inner hit spot in cm"),
-    ("rvsout", 0.0, "major radius of vessel outer hit spot in cm"),
-    ("zvsout", 0.0, "Z of vessel outer hit spot in cm"),
-    ("vsurfa", 0.0, "plasma surface loop voltage in volt, E EQDSK only"),
-    ("wpdot", 0.0, "time derivative of plasma stored energy in Watt, E EQDSK only"),
-    ("wbdot", 0.0, "time derivative of poloidal magnetic energy in Watt, E EQDSK only"),
-    ("slantu", 0.0, ""),
-    ("slantl", 0.0, ""),
-    ("zuperts", 0.0, ""),
-    ("chipre", 0.0, "total chi2 pressure"),
-    ("cjor95", 0.0, ""),
-    ("pp95", 0.0, "normalized P'(y) at 95% normalized poloidal flux"),
-    ("ssep", 0.0, ""),
-    ("yyy2", 0.0, "Shafranov Y2 current moment"),
-    ("xnnc", 0.0, ""),
-    ("cprof", 0.0, "current profile parametrization parameter"),
-    ("oring", 0.0, "not used"),
-    (
-        "cjor0",
-        0.0,
-        dedent(
-            """\
-            normalized flux surface average current density at 99% of normalized
-            poloidal flux
-            """
-        ),
-    ),
-    ("fexpan", 0.0, "flux expansion at x point"),
-    ("qqmin", 0.0, "minimum safety factor qmin"),
-    ("chigamt", 0.0, "total chi2 MSE"),
-    ("ssi01", 0.0, "magnetic shear at 1% of normalized poloidal flux"),
-    ("fexpvs", 0.0, "flux expansion at outer lower vessel hit spot"),
-    (
-        "sepnose",
-        0.0,
-        "radial distance in cm between x point and external field line at ZNOSE",
-    ),
-    ("ssi95", 0.0, "magnetic shear at 95% of normalized poloidal flux"),
-    ("rqqmin", 0.0, "normalized radius of qmin , square root of normalized volume"),
-    ("cjor99", 0.0, ""),
-    (
-        "cj1ave",
-        0.0,
-        dedent(
-            """\
-            normalized average current density in plasma outer 5% normalized poloidal
-            flux region
-            """
-        ),
-    ),
-    ("rmidin", 0.0, "inner major radius in m at Z=0.0"),
-    ("rmidout", 0.0, "outer major radius in m at Z=0.0"),
-]
+from . import _fileutils as fu
+
+# TODO: Documentation does not describe header rows in A-EQDSK file
 
 
-def write(data, fh):
+class Field(NamedTuple):
     """
-    data  [dict] - keys are given with documentation in the `fields` list.
-        Also includes
-         shot [int] - The shot number
-    time  - in ms
+    Helper class for defining each entry in a A-EQDSK file.
+    """
 
+    #: Name of the field used in the resulting dict.
+    name: str
+
+    #: Default value to be assigned to missing fields when writing out an A-EQDSK dict.
+    #: This may be a function which takes the dict as its sole argument, and uses
+    #: existing data to return either an int or a list of floats. For example, the field
+    #: 'rco2v' should contain a list of floats of length 'mco2v', so if 'rco2v' is not
+    #: present, its function returns a list of length 'mco2v' containing only 0.0.
+    #: To determine how keys with callable defaults work, please check the source code.
+    default: Union[float, Callable[[Dict[str, Any]], Union[int, List[float]]]]
+
+    #: Description of the field.
+    description: str
+
+
+def fields() -> List[Field]:
+    """
+    Returns list of A-EQDSK fields, including their default values and descriptions.
+    Used by both ``read`` and ``write``.
+
+    This docstring is dynamically overwritten at the bottom of this module to include
+    the info contained within the returned list.
+    """
+    result = [
+        (
+            "tsaisq",
+            0.0,
+            "total chi2 from magnetic probes, flux loops, Rogowski and external coils",
+        ),
+        ("rcencm", 100.0, "major radius in cm for vacuum field BCENTR"),
+        ("bcentr", 1.0, "vacuum toroidal magnetic field in Tesla at RCENCM"),
+        ("pasmat", 1e6, "measured plasma toroidal current in Ampere"),
+        ("cpasma", 1e6, "fitted plasma toroidal current in Ampere-turn"),
+        ("rout", 100.0, "major radius of geometric center in cm"),
+        ("zout", 0.0, "Z of geometric center in cm"),
+        ("aout", 50.0, "plasma minor radius in cm"),
+        ("eout", 1.0, "Plasma boundary elongation"),
+        ("doutu", 1.0, "upper triangularity"),
+        ("doutl", 1.0, "lower triangularity"),
+        ("vout", 1000.0, "plasma volume in cm3"),
+        ("rcurrt", 100.0, "major radius in cm of current centroid"),
+        ("zcurrt", 0.0, "Z in cm at current centroid"),
+        ("qsta", 5.0, "equivalent safety factor q*"),
+        ("betat", 1.0, "toroidal beta in %"),
+        (
+            "betap",
+            1.0,
+            dedent(
+                """\
+                poloidal beta with normalization average poloidal magnetic BPOLAV\
+                defined through Ampere's law\
+                """
+            ),
+        ),
+        (
+            "ali",
+            0.0,
+            dedent(
+                """\
+                li with normalization average poloidal magnetic defined through\
+                Ampere's law\
+                """
+            ),
+        ),
+        ("oleft", 10.0, "plasma inner gap in cm"),
+        ("oright", 10.0, "plasma outer gap in cm"),
+        ("otop", 10.0, "plasma top gap in cm"),
+        ("obott", 10.0, "plasma bottom gap in cm"),
+        ("qpsib", 5.0, "q at 95% of poloidal flux"),
+        ("vertn", 1.0, "vacuum field (index? seems to be float) at current centroid"),
+        # fmt_1040 = r '^\s*' + 4 * r '([\s\-]\d+\.\d+[Ee][\+\-]\d\d)'
+        # read(neqdsk, 1040)(rco2v(k, jj), k = 1, mco2v)
+        (None, None, None),  # New line
+        (
+            "rco2v",
+            lambda data: [0.0] * data["mco2v"],
+            "1D array : path length in cm of vertical CO2 density chord",
+        ),
+        # read(neqdsk, 1040)(dco2v(jj, k), k = 1, mco2v)
+        (None, None, None),  # New line
+        (
+            "dco2v",
+            lambda data: [0.0] * data["mco2v"],
+            "line average electron density in cm3 from vertical CO2 chord",
+        ),
+        # read(neqdsk, 1040)(rco2r(k, jj), k = 1, mco2r)
+        (None, None, None),  # New line
+        (
+            "rco2r",
+            lambda data: [0.0] * data["mco2r"],
+            "path length in cm of radial CO2 density chord",
+        ),
+        # read(neqdsk, 1040)(dco2r(jj, k), k = 1, mco2r)
+        (None, None, None),  # New line
+        (
+            "dco2r",
+            lambda data: [0.0] * data["mco2r"],
+            "line average electron density in cm3 from radial CO2 chord",
+        ),
+        (None, None, None),  # New line
+        ("shearb", 0.0, ""),
+        (
+            "bpolav",
+            1.0,
+            "average poloidal magnetic field in Tesla defined through Ampere's law",
+        ),
+        ("s1", 0.0, "Shafranov boundary line integrals"),
+        ("s2", 0.0, "Shafranov boundary line integrals"),
+        ("s3", 0.0, "Shafranov boundary line integrals"),
+        ("qout", 0.0, "q at plasma boundary"),
+        ("olefs", 0.0, ""),
+        ("orighs", 0.0, "outer gap of external second separatrix in cm"),
+        ("otops", 0.0, "top gap of external second separatrix in cm"),
+        ("sibdry", 1.0, ""),
+        ("areao", 100.0, "cross sectional area in cm2"),
+        ("wplasm", 0.0, ""),
+        ("terror", 0.0, "equilibrium convergence error"),
+        ("elongm", 0.0, "elongation at magnetic axis"),
+        ("qqmagx", 0.0, "axial safety factor q(0)"),
+        ("cdflux", 0.0, "computed diamagnetic flux in Volt-sec"),
+        ("alpha", 0.0, "Shafranov boundary line integral parameter"),
+        ("rttt", 0.0, "Shafranov boundary line integral parameter"),
+        ("psiref", 1.0, "reference poloidal flux in VS/rad"),
+        (
+            "xndnt",
+            0.0,
+            dedent(
+                """\
+                vertical stability parameter, vacuum field index normalized to critical\
+                index value\
+                """
+            ),
+        ),
+        ("rseps1", 1.0, "major radius of x point in cm"),
+        ("zseps1", -1.0, ""),
+        ("rseps2", 1.0, "major radius of x point in cm"),
+        ("zseps2", 1.0, ""),
+        ("sepexp", 0.0, "separatrix radial expansion in cm"),
+        ("obots", 0.0, "bottom gap of external second separatrix in cm"),
+        ("btaxp", 1.0, "toroidal magnetic field at magnetic axis in Tesla"),
+        ("btaxv", 1.0, "vacuum toroidal magnetic field at magnetic axis in Tesla"),
+        ("aaq1", 100.0, "minor radius of q=1 surface in cm, 100 if not found"),
+        ("aaq2", 100.0, "minor radius of q=2 surface in cm, 100 if not found"),
+        ("aaq3", 100.0, "minor radius of q=3 surface in cm, 100 if not found"),
+        (
+            "seplim",
+            0.0,
+            dedent(
+                """\
+                > 0 for minimum gap in cm in divertor configurations, < 0 absolute\
+                value for minimum distance to external separatrix in limiter\
+                configurations\
+                """
+            ),
+        ),
+        ("rmagx", 100.0, "major radius in cm at magnetic axis"),
+        ("zmagx", 0.0, ""),
+        ("simagx", 0.0, "Poloidal flux at the magnetic axis"),
+        ("taumhd", 0.0, "energy confinement time in ms"),
+        ("betapd", 0.0, "diamagnetic poloidal b"),
+        ("betatd", 0.0, "diamagnetic toroidal b in %"),
+        ("wplasmd", 0.0, "diamagnetic plasma stored energy in Joule"),
+        ("diamag", 0.0, "measured diamagnetic flux in Volt-sec"),
+        ("vloopt", 0.0, "measured loop voltage in volt"),
+        ("taudia", 0.0, "diamagnetic energy confinement time in ms"),
+        (
+            "qmerci",
+            0.0,
+            "Mercier stability criterion on axial q(0), q(0) > QMERCI for stability",
+        ),
+        ("tavem", 0.0, "average time in ms for magnetic and MSE data"),
+        # ishot > 91000
+        # The next section is dependent on the EFIT version
+        # New version of EFIT on 05/24/97 writes aeqdsk that includes
+        # data values for parameters nsilop,magpri,nfcoil and nesum.
+        (None, None, None),  # New line
+        (
+            "nsilop",
+            lambda data: len(data.get("csilop", [])),
+            "Number of flux loop signals, len(csilop)",
+        ),
+        (
+            "magpri",
+            lambda data: len(data.get("cmpr2", [])),
+            "Number of flux loop signals, len(cmpr2) (added to nsilop)",
+        ),
+        (
+            "nfcoil",
+            lambda data: len(data.get("ccbrsp", [])),
+            "Number of calculated external coil currents, len(ccbrsp)",
+        ),
+        (
+            "nesum",
+            lambda data: len(data.get("eccurt", [])),
+            "Number of measured E-coil currents",
+        ),
+        (None, None, None),  # New line
+        (
+            "csilop",
+            lambda data: [0.0] * data.get("nsilop", 0),
+            "computed flux loop signals in Weber",
+        ),
+        ("cmpr2", lambda data: [0.0] * data.get("magpri", 0), ""),
+        (
+            "ccbrsp",
+            lambda data: [0.0] * data.get("nfcoil", 0),
+            "computed external coil currents in Ampere",
+        ),
+        (
+            "eccurt",
+            lambda data: [0.0] * data.get("nesum", 0),
+            "measured E-coil current in Ampere",
+        ),
+        ("pbinj", 0.0, "neutral beam injection power in Watts"),
+        ("rvsin", 0.0, "major radius of vessel inner hit spot in cm"),
+        ("zvsin", 0.0, "Z of vessel inner hit spot in cm"),
+        ("rvsout", 0.0, "major radius of vessel outer hit spot in cm"),
+        ("zvsout", 0.0, "Z of vessel outer hit spot in cm"),
+        ("vsurfa", 0.0, "plasma surface loop voltage in volt, E EQDSK only"),
+        ("wpdot", 0.0, "time derivative of plasma stored energy in Watt, E EQDSK only"),
+        (
+            "wbdot",
+            0.0,
+            "time derivative of poloidal magnetic energy in Watt, E EQDSK only",
+        ),
+        ("slantu", 0.0, ""),
+        ("slantl", 0.0, ""),
+        ("zuperts", 0.0, ""),
+        ("chipre", 0.0, "total chi2 pressure"),
+        ("cjor95", 0.0, ""),
+        ("pp95", 0.0, "normalized P'(y) at 95% normalized poloidal flux"),
+        ("ssep", 0.0, ""),
+        ("yyy2", 0.0, "Shafranov Y2 current moment"),
+        ("xnnc", 0.0, ""),
+        ("cprof", 0.0, "current profile parametrization parameter"),
+        ("oring", 0.0, "not used"),
+        (
+            "cjor0",
+            0.0,
+            dedent(
+                """\
+                normalized flux surface average current density at 99% of normalized\
+                poloidal flux\
+                """
+            ),
+        ),
+        ("fexpan", 0.0, "flux expansion at x point"),
+        ("qqmin", 0.0, "minimum safety factor qmin"),
+        ("chigamt", 0.0, "total chi2 MSE"),
+        ("ssi01", 0.0, "magnetic shear at 1% of normalized poloidal flux"),
+        ("fexpvs", 0.0, "flux expansion at outer lower vessel hit spot"),
+        (
+            "sepnose",
+            0.0,
+            "radial distance in cm between x point and external field line at ZNOSE",
+        ),
+        ("ssi95", 0.0, "magnetic shear at 95% of normalized poloidal flux"),
+        ("rqqmin", 0.0, "normalized radius of qmin , square root of normalized volume"),
+        ("cjor99", 0.0, ""),
+        (
+            "cj1ave",
+            0.0,
+            dedent(
+                """\
+                normalized average current density in plasma outer 5% normalized\
+                poloidal flux region\
+                """
+            ),
+        ),
+        ("rmidin", 0.0, "inner major radius in m at Z=0.0"),
+        ("rmidout", 0.0, "outer major radius in m at Z=0.0"),
+    ]
+    return [Field(*args) for args in result]
+
+
+# Internally, make use of a pre-computed fields
+
+_fields = fields()
+
+
+def write(data: Dict[str, Union[float, int, List[float]]], fh: TextIO) -> None:
+    """
+    Write a dict of A-EQDSK data to a file.
+
+    Parameters
+    ----------
+    data: Dict[str, Union[float, int, List[float]]]
+        The data to write to disk. See the ``aeqdsk.fields`` function for information
+        on what to include. It may also include:
+        - shot: int, The shot number
+        - time: int, The time in milliseconds
+    fh: TextIO
+        File handle to write to. Should be opened in a text write mode, i.e.
+        ``open(filename, "w")``.
     """
     # First line identification string
     # Default to date > 1997 since that format includes nsilop etc.
@@ -296,7 +349,7 @@ def write(data, fh):
     )
     # Output data in lines of 4 values each
     with fu.ChunkOutput(fh, chunksize=4) as output:
-        for key, default, description in fields:
+        for key, default, description in _fields:
             if callable(default):
                 # Replace the default function with the value, which may depend on
                 # previously read data
@@ -308,9 +361,23 @@ def write(data, fh):
                 output.write(data.get(key, default))
 
 
-def read(fh):
+def read(fh: TextIO) -> Dict[str, Union[int, float, List[float]]]:
     """
-    Read an AEQDSK file, returning a dictionary of data
+    Read an A-EQDSK file, returning a dictionary of data.
+
+    Parameters
+    ----------
+    fh: TextIO
+        File handle to write to. Should be opened in a text read mode, i.e.
+        ``open(filename, "r")``.
+
+    Returns
+    -------
+    data: Dict[str, Union[float, int, List[float]]]
+        A-EQDSK data. See the ``aeqdsk.fields`` function for information on what it
+        includes. It will also include (amongst other things):
+        - shot: int, The shot number
+        - time: int, The time in milliseconds
     """
     # First line label. Date.
     header = fh.readline()
@@ -340,7 +407,7 @@ def read(fh):
 
     # Read each value from the file, and put into variables
     values = fu.next_value(fh)
-    for key, default, doc in fields:
+    for key, default, doc in _fields:
         if key is None:
             continue  # skip
 
@@ -359,3 +426,35 @@ def read(fh):
             data[key] = value
 
     return data
+
+
+# Dynamic docstring generation
+
+_fields_docstring_header = dedent(
+    """\
+    A list of A-EQDSK file data variables, their default values, and documentation.
+    This is used in both ``aeqdsk.read`` and ``aeqdsk.write``. The list includes the
+    following:
+
+    .. list-table:: fields
+       :widths: 20 20 60
+       :header-rows: 1
+
+       * - Name
+         - Default
+         - Description
+    """
+)
+
+
+def _table_entry(field: Tuple[str, Union[int, float, Callable], str]) -> str:
+    name, default, description = field
+    name_str = f"   * - {name}"
+    default_str = f"     - {'Callable' if callable(default) else default}"
+    description_str = f"     - {description}"
+    return "\n".join((name_str, default_str, description_str))
+
+
+_fields_docstring_table = "\n".join(_table_entry(field) for field in _fields)
+
+fields.__doc__ = f"{_fields_docstring_header}{_fields_docstring_table}"

--- a/freeqdsk/geqdsk.py
+++ b/freeqdsk/geqdsk.py
@@ -17,6 +17,9 @@ from numpy.typing import ArrayLike
 from ._fileutils import f2s, ChunkOutput, write_1d, write_2d, next_value
 
 
+# TODO: Documentation does not describe G-EQDSK header line
+
+
 def write(
     data: Dict[str, Union[int, float, ArrayLike]],
     fh: TextIO,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ tests = [
     "pytest >= 3.3.0",
     "pytest-cov",
 ]
+docs = [
+    "sphinx == 3.5.4",
+    "myst_parser == 0.14.0",
+    "jinja2 < 3.1.0",
+    "sphinx_rtd_theme",
+]
 dev = [
     "flake8",
     "black",


### PR DESCRIPTION
We'd like to publish Pyrokinetics on conda-forge [(related issue](https://github.com/pyro-kinetics/pyrokinetics/issues/170)), but we're not able to as it uses FreeQDSK as a dependency, and this needs to be on conda-forge first. I think the main barrier to achieving this is just the lack of documentation (it could perhaps use a few more tests too). This PR adds Sphinx docs and generally expands upon docstrings/typehints.

I've added to the docs for `_fileutils.py` and `geqdsk.py` so far, but I don't have access to a good reference for A-EQDSK files, so I'm not sure what to write for them. Please could you let me know where I can find more info on them?

@ZedThree Once merged, would you be able to set up automatic publishing on readthedocs? Or maybe I could figure it out if I were added as a maintainer?