### PR TITLE
Add explicit version requirements for fortranformat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "numpy >= 1.8",
-    "fortranformat",
+    "fortranformat ~= 2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
FortranFormat version 2.0 has significant performance improvements (thanks @ZedThree!). This change ensures our users also benefit from these improvements.

It's a tiny change, but could this prompt a 0.3.1 release?