### PR TITLE
Allows compatibility with python3.7

### DIFF
--- a/freeqdsk/__init__.py
+++ b/freeqdsk/__init__.py
@@ -1,7 +1,10 @@
 __all__ = ["geqdsk", "aeqdsk", "peqdsk"]
 
-from importlib.metadata import version, PackageNotFoundError
-
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ModuleNotFoundError:
+    # Python 3.7
+    from importlib_metadata import version, PackageNotFoundError
 try:
     __version__ = version(__name__)
 except PackageNotFoundError:

--- a/freeqdsk/peqdsk.py
+++ b/freeqdsk/peqdsk.py
@@ -29,8 +29,13 @@ atomic number, charge (in units of :math:`e`), and atomic mass of the ions::
 
 import csv
 import re
-from typing import Dict, Generator, List, TextIO, Tuple, TypedDict, Union
+from typing import Dict, Generator, List, TextIO, Tuple, Union
 
+try:
+    from typing import TypedDict
+except ImportError:
+    # python 3.7
+    from typing_extensions import TypedDict
 import numpy as np
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,12 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 dependencies = [
     "numpy >= 1.8",
     "fortranformat ~= 2.0",
+    "importlib_metadata; python_version < '3.8'",
+    "typing_extensions; python_version < '3.8'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Our user environment still uses python 3.7, and I would like to be able to use FreeQDSK. The following proposal allows installing FreeQDSK under python 3.7 env.