### PR TITLE
Docs: Fix issues with readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -26,4 +26,3 @@ python:
       path: .
       extra_requirements:
         - docs
-  system_packages: true


### PR DESCRIPTION
- `system_packages` no longer supported, breaks the build
- bump OS/python versions